### PR TITLE
fix: Avoid access of resource not created when sqs_queue_arn is defined

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,19 +1,19 @@
 output "queue_arn" {
   description = "Queue arn."
-  value       = aws_sqs_queue.queue[0].arn
+  value       = one(aws_sqs_queue.queue[*].arn)
 }
 
 output "queue_url" {
   description = "Queue url."
-  value       = aws_sqs_queue.queue[0].url
+  value       = one(aws_sqs_queue.queue[*].url)
 }
 
 output "dl_queue_arn" {
   description = "Dead letter queue arn."
-  value       = aws_sqs_queue.dlqueue[0].arn
+  value       = one(aws_sqs_queue.dlqueue[*].arn)
 }
 
 output "dl_queue_url" {
   description = "Dead letter queue url."
-  value       = aws_sqs_queue.dlqueue[0].url
+  value       = one(aws_sqs_queue.dlqueue[*].url)
 }


### PR DESCRIPTION
## What

Hey all, 👋🏽 

There is a case when passing the `sqs_queue_arn` variable to the module the output tries to access the resource not created.

## Why

fix: To use the module with a pre-existent sqs queue.

## Notes
The function `one` is supported since Terraform 0.15 https://developer.hashicorp.com/terraform/language/functions/one
