### PR TITLE
feat: Add lambda function ARN and name to outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3]
+* Adds `lambda_function_arn` and `lambda_function_name` as outputs
+
 ## [0.1.2]
 * Fix output error when `sqs_queue_arn` is passed in
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.1.3]
-* Adds `lambda_function_arn` and `lambda_function_name` as outputs
+* Adds `lambda_function_arn` as output
 
 ## [0.1.2]
 * Fix output error when `sqs_queue_arn` is passed in

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ No modules.
 | <a name="output_dl_queue_url"></a> [dl\_queue\_url](#output\_dl\_queue\_url) | Dead letter queue url. |
 | <a name="output_queue_arn"></a> [queue\_arn](#output\_queue\_arn) | Queue arn. |
 | <a name="output_queue_url"></a> [queue\_url](#output\_queue\_url) | Queue url. |
-| <a name="output_lambda_function_arn"></a> [arn](#output\_arn) | Lambda function ARN. |
+| <a name="output_lambda_function_arn"></a> [lambda\_function\_arn](#output\_lambda\_function\_arn) | Lambda function ARN. |
 
 
 ## About harrison.ai

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ No modules.
 | <a name="output_dl_queue_url"></a> [dl\_queue\_url](#output\_dl\_queue\_url) | Dead letter queue url. |
 | <a name="output_queue_arn"></a> [queue\_arn](#output\_queue\_arn) | Queue arn. |
 | <a name="output_queue_url"></a> [queue\_url](#output\_queue\_url) | Queue url. |
+| <a name="output_lambda_function_arn"></a> [lambda\_function\_arn](#output\_lambda\_function\_arn) | Lambda function ARN. |
+| <a name="output_lambda_function_name"></a> [lambda\_function\_name](#output\_lambda\_function\_name) | Lambda function name. |
 
 
 ## About harrison.ai

--- a/README.md
+++ b/README.md
@@ -81,8 +81,7 @@ No modules.
 | <a name="output_dl_queue_url"></a> [dl\_queue\_url](#output\_dl\_queue\_url) | Dead letter queue url. |
 | <a name="output_queue_arn"></a> [queue\_arn](#output\_queue\_arn) | Queue arn. |
 | <a name="output_queue_url"></a> [queue\_url](#output\_queue\_url) | Queue url. |
-| <a name="output_lambda_function_arn"></a> [lambda\_function\_arn](#output\_lambda\_function\_arn) | Lambda function ARN. |
-| <a name="output_lambda_function_name"></a> [lambda\_function\_name](#output\_lambda\_function\_name) | Lambda function name. |
+| <a name="output_lambda_function_arn"></a> [arn](#output\_arn) | Lambda function ARN. |
 
 
 ## About harrison.ai

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,7 +18,7 @@ output "dl_queue_url" {
   value       = one(aws_sqs_queue.dlqueue[*].url)
 }
 
-output "arn" {
+output "lambda_function_arn" {
   description = "Lambda function arn."
   value       = aws_lambda_function.this.arn
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,12 +18,7 @@ output "dl_queue_url" {
   value       = one(aws_sqs_queue.dlqueue[*].url)
 }
 
-output "lambda_function_arn" {
+output "arn" {
   description = "Lambda function arn."
-  value       = aws_lambda_function.this[*].lambda_function_arn
-}
-
-output "lambda_function_name" {
-  description = "Lambda function name."
-  value       = aws_lambda_function.this[*].lambda_function_name
+  value       = aws_lambda_function.this.arn
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,13 @@ output "dl_queue_url" {
   description = "Dead letter queue url."
   value       = one(aws_sqs_queue.dlqueue[*].url)
 }
+
+output "lambda_function_arn" {
+  description = "Lambda function arn."
+  value       = one(aws_lambda_function.this.lambda_function_arn)
+}
+
+output "lambda_function_name" {
+  description = "Lambda function name."
+  value       = one(aws_lambda_function.this.lambda_function_name)
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,10 +20,10 @@ output "dl_queue_url" {
 
 output "lambda_function_arn" {
   description = "Lambda function arn."
-  value       = one(aws_lambda_function.this.lambda_function_arn)
+  value       = one(aws_lambda_function.this[*].lambda_function_arn)
 }
 
 output "lambda_function_name" {
   description = "Lambda function name."
-  value       = one(aws_lambda_function.this.lambda_function_name)
+  value       = one(aws_lambda_function.this[*].lambda_function_name)
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,10 +20,10 @@ output "dl_queue_url" {
 
 output "lambda_function_arn" {
   description = "Lambda function arn."
-  value       = one(aws_lambda_function.this[*].lambda_function_arn)
+  value       = aws_lambda_function.this[*].lambda_function_arn
 }
 
 output "lambda_function_name" {
   description = "Lambda function name."
-  value       = one(aws_lambda_function.this[*].lambda_function_name)
+  value       = aws_lambda_function.this[*].lambda_function_name
 }


### PR DESCRIPTION
## What

Adds module re-exports for `lambda_function_arn` and `lambda_function_name`

## Why

There are some use cases in JVs that require using the `lambda_function_arn` as an input for things like S3 Object Lambda Access Points, Lambda resource policies, and other resources that reference `lambda_function_arn` or `lambda_function_name`.
