### PR TITLE
Support reserved_concurrent_executions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -46,8 +46,12 @@ resource "aws_lambda_function" "this" {
 
   depends_on = [aws_cloudwatch_log_group.this]
 
-  lifecycle {
-    ignore_changes = var.reserved_concurrent_executions == -1 ? [reserved_concurrent_executions] : []
+  dynamic "lifecycle" {
+    for_each = var.reserved_concurrent_executions == -1 ? [true] : []
+
+    content {
+      ignore_changes = [reserved_concurrent_executions]
+    }
   }
 
 }

--- a/main.tf
+++ b/main.tf
@@ -18,10 +18,11 @@ resource "aws_lambda_function" "this" {
     command     = var.command
     entry_point = var.entry_point
   }
-  image_uri    = var.image_uri
-  memory_size  = var.memory_size
-  package_type = "Image"
-  timeout      = var.timeout
+  image_uri                      = var.image_uri
+  memory_size                    = var.memory_size
+  package_type                   = "Image"
+  timeout                        = var.timeout
+  reserved_concurrent_executions = var.reserved_concurrent_executions
 
   dynamic "environment" {
     for_each = length(keys(var.envvars)) == 0 ? [] : [true]
@@ -46,7 +47,7 @@ resource "aws_lambda_function" "this" {
   depends_on = [aws_cloudwatch_log_group.this]
 
   lifecycle {
-    ignore_changes = [reserved_concurrent_executions]
+    ignore_changes = var.reserved_concurrent_executions == -1 ? [reserved_concurrent_executions] : []
   }
 
 }

--- a/variables.tf
+++ b/variables.tf
@@ -90,6 +90,12 @@ variable "iam_abac_tags" {
   default     = {}
 }
 
+variable "reserved_concurrent_executions" {
+  description = "The amount of reserved concurrent executions for this Lambda Function. A value of 0 disables Lambda Function from being triggered and -1 removes any concurrency limitations. Defaults to Unreserved Concurrency Limits -1."
+  type        = number
+  default     = -1
+}
+
 ##  -----  SQS Variables  -----  ##
 
 variable "sqs_queue_arn" {


### PR DESCRIPTION
## Depends on

N/A

## What

Support reserved_concurrent_executions. When set to a value other than default, will not lifecycle ignore this value.

## Why

Would like to specify a custom value of Support reserved_concurrent_executions via terraform.
