### PR TITLE
Add function_response_types to event source mapping

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,61 +15,61 @@ TF_DIR = tf/$(ENVIRONMENT)
 
 ## init:			terraform init
 init: .env
-	docker-compose run --rm envvars ensure --tags terraform
-	docker-compose run --rm --workdir /app/$(TF_DIR) terraform init
+	docker compose run --rm envvars ensure --tags terraform
+	docker compose run --rm --workdir /app/$(TF_DIR) terraform init
 
 ## init-upgrade:		terraform init -upgrade
 init-upgrade: .env
-	docker-compose run --rm envvars ensure --tags terraform
-	docker-compose run --rm --workdir /app/$(TF_DIR) terraform init -upgrade
+	docker compose run --rm envvars ensure --tags terraform
+	docker compose run --rm --workdir /app/$(TF_DIR) terraform init -upgrade
 
 ## fmt: 			terraform fmt -recursive
 fmt: .env
-	docker-compose run --rm --workdir /app terraform fmt -recursive
+	docker compose run --rm --workdir /app terraform fmt -recursive
 
 ## ci-fmt:			terraform fmt -recursive -check -diff -write=false
 ci-fmt:
 	touch .env
-	docker-compose run --rm --workdir /app terraform fmt -recursive -check -diff -write=false
+	docker compose run --rm --workdir /app terraform fmt -recursive -check -diff -write=false
 
 ## plan:			terraform plan
 plan: .env
-	docker-compose run --rm envvars ensure --tags terraform
-	docker-compose run --rm --workdir /app/$(TF_DIR) terraform plan
+	docker compose run --rm envvars ensure --tags terraform
+	docker compose run --rm --workdir /app/$(TF_DIR) terraform plan
 
 ## plan-print:		terraform plan -no-color | tee plan-<date>.out
 plan-print: .env
-	docker-compose run --rm envvars ensure --tags terraform
-	docker-compose run --rm --workdir /app/$(TF_DIR) terraform plan -no-color | tee plan-${DATESTRING}.out
+	docker compose run --rm envvars ensure --tags terraform
+	docker compose run --rm --workdir /app/$(TF_DIR) terraform plan -no-color | tee plan-${DATESTRING}.out
 
 ## apply:			terraform apply
 apply: .env
-	docker-compose run --rm envvars ensure --tags terraform
-	docker-compose run --rm --workdir /app/$(TF_DIR) terraform apply
+	docker compose run --rm envvars ensure --tags terraform
+	docker compose run --rm --workdir /app/$(TF_DIR) terraform apply
 
 ## validate: 		terraform validate across all environments
 validate:
-	docker-compose run --rm --workdir /app terraform init -backend=false
-	docker-compose run --rm --workdir /app terraform validate -json
+	docker compose run --rm --workdir /app terraform init -backend=false
+	docker compose run --rm --workdir /app terraform validate -json
 
 ## destroy:		terraform destroy
 destroy: .env
-	docker-compose run --rm envvars ensure --tags terraform
-	docker-compose run --rm --workdir /app/$(TF_DIR) terraform destroy
+	docker compose run --rm envvars ensure --tags terraform
+	docker compose run --rm --workdir /app/$(TF_DIR) terraform destroy
 
 ## tf-shell:		opens a shell inside the terraform container
 tf-shell: .env
-	docker-compose run --rm envvars ensure --tags terraform
-	docker-compose run --rm --entrypoint='' terraform /bin/ash
+	docker compose run --rm envvars ensure --tags terraform
+	docker compose run --rm --entrypoint='' terraform /bin/ash
 
 ## pull:			docker-compose pull
 pull:
-	docker-compose pull
+	docker compose pull
 
 ## .env:			creates .env file with the envvar keys populated
 .env:
 	touch .env
-	docker-compose run --rm envvars envfile --overwrite --example
+	docker compose run --rm envvars envfile --overwrite --example
 
 ## help:			show this help
 help:

--- a/main.tf
+++ b/main.tf
@@ -58,6 +58,7 @@ resource "aws_lambda_event_source_mapping" "this" {
   function_name                      = aws_lambda_function.this.function_name
   batch_size                         = var.batch_size
   maximum_batching_window_in_seconds = var.maximum_batching_window_in_seconds
+  function_response_types            = var.function_response_types
 }
 
 resource "aws_sqs_queue" "queue" {

--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ resource "aws_lambda_event_source_mapping" "this" {
   function_name                      = aws_lambda_function.this.function_name
   batch_size                         = var.batch_size
   maximum_batching_window_in_seconds = var.maximum_batching_window_in_seconds
-  function_response_types            = var.function_response_types
+  function_response_types            = try(var.function_response_types, null)
 }
 
 resource "aws_sqs_queue" "queue" {

--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,7 @@ resource "aws_lambda_event_source_mapping" "this" {
   function_name                      = aws_lambda_function.this.function_name
   batch_size                         = var.batch_size
   maximum_batching_window_in_seconds = var.maximum_batching_window_in_seconds
-  function_response_types            = try(var.function_response_types, null)
+  function_response_types            = var.function_response_types
 }
 
 resource "aws_sqs_queue" "queue" {

--- a/variables.tf
+++ b/variables.tf
@@ -51,8 +51,8 @@ variable "maximum_batching_window_in_seconds" {
 
 variable "function_response_types" {
   description = "Set to ReportBatchItemFailures to allow Lambda to return paritial success/failures."
-  type        = string
-  default     = null
+  type        = list(string)
+  default     = []
 }
 
 variable "cloudwatch_retention_in_days" {

--- a/variables.tf
+++ b/variables.tf
@@ -49,6 +49,12 @@ variable "maximum_batching_window_in_seconds" {
   default     = 30
 }
 
+variable "function_response_types" {
+  description = "Set to ReportBatchItemFailures to allow Lambda to return paritial success/failures."
+  type        = string
+  # default     = null
+}
+
 variable "cloudwatch_retention_in_days" {
   description = "Days to keep Cloudwatch logs before they are deleted."
   type        = number

--- a/variables.tf
+++ b/variables.tf
@@ -52,7 +52,7 @@ variable "maximum_batching_window_in_seconds" {
 variable "function_response_types" {
   description = "Set to ReportBatchItemFailures to allow Lambda to return paritial success/failures."
   type        = string
-  # default     = null
+  default     = null
 }
 
 variable "cloudwatch_retention_in_days" {


### PR DESCRIPTION
## What

Add function_response_types to event source mapping

## Why

So lambdas have the option to return partial failures, returning items to the queue.