### PR TITLE
task: Avoid empty `image_config` block

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -14,10 +14,14 @@ resource "aws_lambda_function" "this" {
     size = var.ephemeral_storage_size
   }
 
-  image_config {
-    command     = var.command
-    entry_point = var.entry_point
+  dynamic "image_config" {
+    for_each = (var.command == null && var.entry_point == null) ? [] : [true]
+    content {
+      command     = var.command
+      entry_point = var.entry_point
+    }
   }
+
   image_uri    = var.image_uri
   memory_size  = var.memory_size
   package_type = "Image"


### PR DESCRIPTION
## What

This PR makes the `image_config` block dynamic, so that it's only included if its not empy.

## Why

This avoids the situation where we end up with recurring empty blocks in our plans, e.g:

```
  # module.report_text_olap_lambda.aws_lambda_function.this will be updated in-place
  ~ resource "aws_lambda_function" "this" {
        id                             = "datalake-report-text-olap-dev"
        tags                           = {
            "Name" = "datalake-report-text-olap-dev"
        }
        # (22 unchanged attributes hidden)

      + image_config {}

        # (4 unchanged blocks hidden)
    }
```

## Concerns

N/A
