### PR TITLE
task: Update default log retention to 365 days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0]
+* Updates default value of `cloudwatch_retention_in_days` to `365` to obtain SOC2 compliance by default
+
 ## [0.1.3]
 * Adds `lambda_function_arn` as output
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @harrison-ai/platform
+* @harrison-ai/devops

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This module is opinionated, yet flexible enough to be really useful. Here are so
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.92.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 
@@ -53,7 +53,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_architectures"></a> [architectures](#input\_architectures) | Architectures to use. For example x86\_64. | `list(string)` | n/a | yes |
 | <a name="input_batch_size"></a> [batch\_size](#input\_batch\_size) | The largest number of records that Lambda will retrieve from the queue at the time of invocation. Defaults to 10 for SQS. | `number` | `10` | no |
-| <a name="input_cloudwatch_retention_in_days"></a> [cloudwatch\_retention\_in\_days](#input\_cloudwatch\_retention\_in\_days) | Days to keep Cloudwatch logs before they are deleted. | `number` | `30` | no |
+| <a name="input_cloudwatch_retention_in_days"></a> [cloudwatch\_retention\_in\_days](#input\_cloudwatch\_retention\_in\_days) | Days to keep Cloudwatch logs before they are deleted. Defaults to 365 days for SOC 2 compliance. | `number` | `365` | no |
 | <a name="input_command"></a> [command](#input\_command) | Command to run in Lambda. This is equivalent to Docker CMD. | `list(string)` | `null` | no |
 | <a name="input_description"></a> [description](#input\_description) | Description of the Lambda. | `string` | n/a | yes |
 | <a name="input_entry_point"></a> [entry\_point](#input\_entry\_point) | Entrypoint of Lambda. This is equivalent to Docker ENTRYPOINT. | `list(string)` | `null` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -56,9 +56,9 @@ variable "function_response_types" {
 }
 
 variable "cloudwatch_retention_in_days" {
-  description = "Days to keep Cloudwatch logs before they are deleted."
+  description = "Days to keep Cloudwatch logs before they are deleted. Defaults to 365 days for SOC 2 compliance."
   type        = number
-  default     = 30
+  default     = 365
 }
 
 variable "envvars" {


### PR DESCRIPTION
## What

This PR updates the lambda module to include a default log retention time of 365 days.

## Why

A log retention time of 365 days is a requirement for SOC 2 compliance, and the cloudwatch log retention times for lambdas is detected by Vanta (our compliance system). We want our lambdas to be compliant by default, so we're updating the default here, rather than applying it manually to all existing lambdas. 

## Concerns

For extremely log heavy lambdas there's the potential of a cost increase. In practice however, this should not be an issue, given the pricing structure of logs, 

The example below (taken from https://aws.amazon.com/cloudwatch/pricing/) shows that the retention cost is swamped by the generation cost. Retaining for 12 months in the example below would cost `$0.36` for a generation cost of `$12.50`, or roughly a 2.5% increase in total cost of the logs.

The impact on the vast majority of our systems should be negligible, and any instances where it's an issue can always re-configure back to a shorter retention time as an exception.

```
If you are monitoring HTTP 2xx, 3xx & 4xx response codes using web application access logs 24x7 for one 30-day month, by sending 1GB per day of ingested log data, monitoring for HTTP responses, and archiving the data for one month, your charges would be as follows:

Monthly Ingested Log Charges
Total log data ingested = 1GB * 30 days = 30GB
0 to 5GB = $0
5 to 30GB = $0.50 * 25 = $12.50

Monthly Monitoring Charges
3 CloudWatch Metrics @$0 = 3 * $0 = $0

Monthly Archived Log Charges (assume log data compresses to 6GB)
0 to 5GB = $0
5GB to 6GB = $0.03 * 1 = $0.03

Monthly CloudWatch Charges = $12.50 + $0 + $0.03 = $12.53
```


* See the [data engineering handbook](https://dataengineering.harrisonai.io/pages/source_control.html#anatomy-of-a-pull-request) for more info.
